### PR TITLE
ASSETS-20566 Retry sending event on 204 response

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        node-version: [10.16, 10.19, 12.16, 12.19, 14.16.1]
+        node-version: [10.16, 10.19, 12.16, 12.19, 14.17]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -42,10 +42,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - name: Use Node.js 12.19
+      - name: Use Node.js 14.17
         uses: actions/setup-node@v1
         with:
-          node-version: '12.19'
+          node-version: '14.17'
       - run: npm install
       - run: npm run semantic-release
         env:

--- a/lib/events.js
+++ b/lib/events.js
@@ -231,13 +231,10 @@ class AdobeIOEvents {
      */
     async sendEvent(event, retryOptions) {
         const url = `${INGRESS_HOST[this.env]}/api/events`;
-        function retryOnHttpResponse(response) {
-            // retry on any 5xx status codes and on 204(IO events cache issue)
-            if (response && (response.status === 204 || response.status >= 500 )) {
-                return true;
-            }
-            return false;
-        }
+        const retryOnHttpResponse = (response) => {
+            // retry on any 5xx status codes and on 204 (IO events cache issue)
+            return (response && (response.status === 204 || response.status >= 500 ));
+        };
         if (typeof retryOptions === 'object') {
             if(!retryOptions.retryOnHttpResponse) {
                 retryOptions.retryOnHttpResponse = retryOnHttpResponse;

--- a/lib/events.js
+++ b/lib/events.js
@@ -241,7 +241,9 @@ class AdobeIOEvents {
         if (typeof retryOptions === 'object') {
             retryOptions.retryOnHttpResponse = retryOnHttpResponse;
         } else {
-            retryOptions = true;
+            retryOptions = {
+                retryOnHttpResponse: retryOnHttpResponse
+            };
         }
 
         const response = await fetch(url, {

--- a/lib/events.js
+++ b/lib/events.js
@@ -229,7 +229,7 @@ class AdobeIOEvents {
      * @param {RetryOptions} retryOptions retry options. If set to false, retry functionality will be disabled. If not set, it will use the default times
      * @returns {Promise}
      */
-    async sendEvent(event, retryOptions=true) {
+    async sendEvent(event, retryOptions) {
         const url = `${INGRESS_HOST[this.env]}/api/events`;
         function retryOnHttpResponse(response) {
             // retry on any 5xx status codes and on 204(IO events cache issue)
@@ -238,6 +238,12 @@ class AdobeIOEvents {
             }
             return false;
         }
+        if (typeof retryOptions === 'object') {
+            retryOptions.retryOnHttpResponse = retryOnHttpResponse;
+        } else {
+            retryOptions = true;
+        }
+
         const response = await fetch(url, {
             method: 'POST',
             headers: {
@@ -252,9 +258,7 @@ class AdobeIOEvents {
                 event_code: event.code,
                 event: Buffer.from(JSON.stringify(event.payload || {})).toString('base64')
             }),
-            retryOptions: {
-                retryOnHttpResponse: retryOnHttpResponse
-            }
+            retryOptions
         });
         if (response.status !== 200) {
             // If retry is disabled then anything other than 200 is considered an error

--- a/lib/events.js
+++ b/lib/events.js
@@ -262,7 +262,7 @@ class AdobeIOEvents {
                 event_code: event.code,
                 event: Buffer.from(JSON.stringify(event.payload || {})).toString('base64')
             }),
-            retryOptions
+            retryOptions: retryOptions
         });
         if (response.status !== 200) {
             // If retry is disabled then anything other than 200 is considered an error

--- a/lib/events.js
+++ b/lib/events.js
@@ -242,7 +242,7 @@ class AdobeIOEvents {
             if(!retryOptions.retryOnHttpResponse) {
                 retryOptions.retryOnHttpResponse = retryOnHttpResponse;
             }
-        } else {
+        } else if(retryOptions !== false) {
             retryOptions = {
                 retryOnHttpResponse: retryOnHttpResponse
             };

--- a/lib/events.js
+++ b/lib/events.js
@@ -239,7 +239,9 @@ class AdobeIOEvents {
             return false;
         }
         if (typeof retryOptions === 'object') {
-            retryOptions.retryOnHttpResponse = retryOnHttpResponse;
+            if(!retryOptions.retryOnHttpResponse) {
+                retryOptions.retryOnHttpResponse = retryOnHttpResponse;
+            }
         } else {
             retryOptions = {
                 retryOnHttpResponse: retryOnHttpResponse

--- a/lib/events.js
+++ b/lib/events.js
@@ -231,6 +231,13 @@ class AdobeIOEvents {
      */
     async sendEvent(event, retryOptions=true) {
         const url = `${INGRESS_HOST[this.env]}/api/events`;
+        function retryOnHttpResponse(response) {
+            // retry on any 5xx status codes and on 204(IO events cache issue)
+            if (response && (response.status === 204 || response.status >= 500 )) {
+                return true;
+            }
+            return false;
+        }
         const response = await fetch(url, {
             method: 'POST',
             headers: {
@@ -245,7 +252,9 @@ class AdobeIOEvents {
                 event_code: event.code,
                 event: Buffer.from(JSON.stringify(event.payload || {})).toString('base64')
             }),
-            retryOptions: retryOptions
+            retryOptions: {
+                retryOnHttpResponse: retryOnHttpResponse
+            }
         });
         if (response.status !== 200) {
             // If retry is disabled then anything other than 200 is considered an error

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -548,6 +548,53 @@ describe('Test retry', () => {
         });
     });
 
+    it('should not override retryOnHttpResponse if present', async () => {
+        const AdobeIOEvents = require('../lib/events');
+        const ioEvents2 = new AdobeIOEvents({
+            accessToken: FAKE_ACCESS_TOKEN,
+            orgId: FAKE_ORG_ID,
+            defaults: {}
+        });
+        const base_url = "https://eg-ingress.adobe.io";
+        const path = "/api/events";
+        nock(base_url)
+            .matchHeader('Authorization',`Bearer ${FAKE_ACCESS_TOKEN}`)
+            .matchHeader('x-ims-org-id',FAKE_ORG_ID)
+            .post(path)
+            .reply(504);
+        nock(base_url)
+            .matchHeader('Authorization',`Bearer ${FAKE_ACCESS_TOKEN}`)
+            .matchHeader('x-ims-org-id',FAKE_ORG_ID)
+            .post(path)
+            .reply(204);
+        nock(base_url)
+            .matchHeader('Authorization',`Bearer ${FAKE_ACCESS_TOKEN}`)
+            .matchHeader('x-ims-org-id',FAKE_ORG_ID)
+            .post(path)
+            .reply(200, {status:200, statusText:'Success!'});
+        let threw = false;
+        try {
+            await ioEvents2.sendEvent({
+                code: 'test_event',
+                payload: {
+                    hello: "world"
+                }
+            },
+            {
+                retryMaxDuration:300,
+                retryInitialDelay:100,
+                retryOnHttpResponse: (response) => { return response.status >= 500; }
+            });
+        } catch(e)  {
+            console.log(`Expected error: ${e.message}`);
+            assert.equal(e.message, "204 No Content");
+            threw = true;
+        }
+        assert.ok(threw);
+        assert(! nock.isDone());
+        nock.cleanAll();
+    });
+
     it('should succeed in sending an event after three retries when "as" attribute given into params', async () => {
         const AdobeIOEvents = require('../lib/events');
 

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -486,6 +486,68 @@ describe('Test retry', () => {
         });
     });
 
+    it('should retry for 204 0r 5xx', async () => {
+        const AdobeIOEvents = require('../lib/events');
+        const ioEvents2 = new AdobeIOEvents({
+            accessToken: FAKE_ACCESS_TOKEN,
+            orgId: FAKE_ORG_ID,
+            defaults: {}
+        });
+        const base_url = "https://eg-ingress.adobe.io";
+        const path = "/api/events";
+        nock(base_url)
+            .matchHeader('Authorization',`Bearer ${FAKE_ACCESS_TOKEN}`)
+            .matchHeader('x-ims-org-id',FAKE_ORG_ID)
+            .post(path)
+            .reply(504);
+        nock(base_url)
+            .matchHeader('Authorization',`Bearer ${FAKE_ACCESS_TOKEN}`)
+            .matchHeader('x-ims-org-id',FAKE_ORG_ID)
+            .post(path)
+            .reply(204);
+        nock(base_url)
+            .matchHeader('Authorization',`Bearer ${FAKE_ACCESS_TOKEN}`)
+            .matchHeader('x-ims-org-id',FAKE_ORG_ID)
+            .post(path)
+            .reply(200, {status:200, statusText:'Success!'});
+
+        await ioEvents2.sendEvent({
+            code: 'test_event',
+            payload: {
+                hello: "world"
+            }
+        });
+    });
+
+    it('should retry three times for 204', async () => {
+        const AdobeIOEvents = require('../lib/events');
+        const ioEvents2 = new AdobeIOEvents({
+            accessToken: FAKE_ACCESS_TOKEN,
+            orgId: FAKE_ORG_ID,
+            defaults: {}
+        });
+        const base_url = "https://eg-ingress.adobe.io";
+        const path = "/api/events";
+        nock(base_url)
+            .matchHeader('Authorization',`Bearer ${FAKE_ACCESS_TOKEN}`)
+            .matchHeader('x-ims-org-id',FAKE_ORG_ID)
+            .post(path)
+            .thrice()
+            .reply(204);
+        nock(base_url)
+            .matchHeader('Authorization',`Bearer ${FAKE_ACCESS_TOKEN}`)
+            .matchHeader('x-ims-org-id',FAKE_ORG_ID)
+            .post(path)
+            .reply(200, {status:200, statusText:'Success!'});
+
+        await ioEvents2.sendEvent({
+            code: 'test_event',
+            payload: {
+                hello: "world"
+            }
+        });
+    });
+
     it('should succeed in sending an event after three retries when "as" attribute given into params', async () => {
         const AdobeIOEvents = require('../lib/events');
 


### PR DESCRIPTION
For https://jira.corp.adobe.com/browse/ASSETS-20566
Recently IO Events returns 204, because of a cache issue in their infrastructure.

Fixes # (issue)
https://jira.corp.adobe.com/browse/ASSETS-20566 and https://jira.corp.adobe.com/browse/ASSETS-20492 (for this repo)

## Types of changes
Code Changes:
- Code changes to retry for 204(in addition to 5xx) when sending IO Events
- Add unit tests
- - update node version to 14.17 for automated release

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
