### PR TITLE
Handle 409 error from IO Events - when multiple journals with name "Asset Compute Journal"

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -301,6 +301,7 @@ class AdobeIOEvents {
 
     /**
      * Fetches a journal or webhook registration.
+     * @param {Journal} journal The journal to create
      * @param {String} registrationId the id of the event listener registration to fetch
      * @returns {Promise}
      */
@@ -374,21 +375,18 @@ class AdobeIOEvents {
             body: JSON.stringify(body),
             retryOptions: retryOptions
         });
-        try {
-            response = handleFetchErrors(response).json();
-            return response;
-        }
-        catch (e) {
-            if (e.statusCode === 409) {
-                console.error("Journal already exists, returning existing");
-                const headers = response.headers.raw();
-                const conflictingRegistrationId = headers['x-conflicting-id'][0];
-                if (!headers || !conflictingRegistrationId) {
-                    throw e;
-                }
-                return this.getJournal(journal, conflictingRegistrationId);
+
+        if (response.status === 409) {
+            console.error("Journal already exists, returning existing");
+            const conflictingRegistrationId = response.headers['x-conflicting-id'];
+            if (!conflictingRegistrationId) {
+                console.error("Could not find conflicting registration id in response headers");
+                throw new Error("Could not find conflicting registration id in response headers");
             }
+            return this.getJournal(journal, conflictingRegistrationId);
         }
+
+        return handleFetchErrors(response).json();
     }
 
     /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -356,7 +356,7 @@ class AdobeIOEvents {
             response = handleFetchErrors(response).json();
         }
         catch (e) {
-            if (error.statusCode === 409) {
+            if (e.statusCode === 409) {
                 console.error("Journal already exists, returning ID");
                 const headers = response.headers.raw();
                 response.registration_id = headers['x-conflicting-id'][0];

--- a/lib/events.js
+++ b/lib/events.js
@@ -300,6 +300,28 @@ class AdobeIOEvents {
     }
 
     /**
+     * Fetches a journal or webhook registration.
+     * @param {String} registrationId the id of the event listener registration to fetch
+     * @returns {Promise}
+     */
+    async getJournal(journal, registrationId, retryOptions=true) {
+        const consumerId = journal.consumerId || this.defaults.consumerId;
+        const applicationId = journal.applicationId || this.defaults.applicationId;
+
+        const url =`${IO_API_HOST[this.env]}/events/organizations/${consumerId}/integrations/${applicationId}/registrations/${registrationId}`;
+        const response = await fetch(url,{
+            method: 'GET',
+            headers: {
+                'x-api-key': this.auth.clientId,
+                'x-ims-org-id': this.auth.orgId,
+                'Authorization': `Bearer ${this.auth.accessToken}`,
+            },
+            retryOptions: retryOptions
+        });
+        return handleFetchErrors(response).json();
+    }
+
+    /**
      * @typedef {Object} Journal
      * @property {String} name Name of the journal (required)
      * @property {String} description Description of the journal (required)
@@ -354,6 +376,7 @@ class AdobeIOEvents {
         });
         try {
             response = handleFetchErrors(response).json();
+            return response;
         }
         catch (e) {
             if (e.statusCode === 409) {
@@ -363,29 +386,9 @@ class AdobeIOEvents {
                 if (!headers || !conflictingRegistrationId) {
                     throw e;
                 }
-                return await getJournal(conflictingRegistrationId);
+                return await this.getJournal(journal, conflictingRegistrationId);
             }
         }
-        return response;
-    }
-
-    /**
-     * Fetches a journal or webhook registration.
-     * @param {String} registrationId the id of the event listener registration to fetch
-     * @returns {Promise}
-     */
-    async getJournal(registrationId, retryOptions=true) {
-        const url =`${IO_API_HOST[this.env]}/events/organizations/${consumerId}/integrations/${applicationId}/registrations/${registrationId}`;
-        let response = await fetch(url,{
-            method: 'GET',
-            headers: {
-                'x-api-key': this.auth.clientId,
-                'x-ims-org-id': this.auth.orgId,
-                'Authorization': `Bearer ${this.auth.accessToken}`,
-            },
-            retryOptions: retryOptions
-        });
-        return handleFetchErrors(response).json();
     }
 
     /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -364,7 +364,7 @@ class AdobeIOEvents {
         const applicationId = journal.applicationId || this.defaults.applicationId;
 
         const url =`${IO_API_HOST[this.env]}/events/organizations/${consumerId}/integrations/${applicationId}/registrations`;
-        let response = await fetch(url, {
+        const response = await fetch(url, {
             method: 'POST',
             headers: {
                 'x-api-key': this.auth.clientId,

--- a/lib/events.js
+++ b/lib/events.js
@@ -341,8 +341,7 @@ class AdobeIOEvents {
         const applicationId = journal.applicationId || this.defaults.applicationId;
 
         const url =`${IO_API_HOST[this.env]}/events/organizations/${consumerId}/integrations/${applicationId}/registrations`;
-
-        const response = await fetch(url,{
+        let response = await fetch(url,{
             method: 'POST',
             headers: {
                 'x-api-key': this.auth.clientId,
@@ -353,8 +352,19 @@ class AdobeIOEvents {
             body: JSON.stringify(body),
             retryOptions: retryOptions
         });
-
-        return handleFetchErrors(response).json();
+        try {
+            response = handleFetchErrors(response).json();
+        }
+        catch (e) {
+            if (error.statusCode === 409) {
+                console.error("Journal already exists, returning ID");
+                const headers = response.headers.raw();
+                response.registration_id = headers['x-conflicting-id'][0];
+            }
+        }
+        finally {
+            return response;
+        }
     }
 
     /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -359,12 +359,13 @@ class AdobeIOEvents {
             if (e.statusCode === 409) {
                 console.error("Journal already exists, returning ID");
                 const headers = response.headers.raw();
+                if (headers['x-conflicting-id'] === undefined) {
+                    throw e;
+                }
                 response.registration_id = headers['x-conflicting-id'][0];
             }
         }
-        finally {
-            return response;
-        }
+        return response;
     }
 
     /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -381,7 +381,7 @@ class AdobeIOEvents {
             const conflictingRegistrationId = response.headers['x-conflicting-id'];
             if (!conflictingRegistrationId) {
                 console.error("Could not find conflicting registration id in response headers");
-                throw new Error("Could not find conflicting registration id in response headers");
+                return handleFetchErrors(response);
             }
             return this.getJournal(journal, conflictingRegistrationId);
         }

--- a/lib/events.js
+++ b/lib/events.js
@@ -386,7 +386,7 @@ class AdobeIOEvents {
                 if (!headers || !conflictingRegistrationId) {
                     throw e;
                 }
-                return await this.getJournal(journal, conflictingRegistrationId);
+                return this.getJournal(journal, conflictingRegistrationId);
             }
         }
     }

--- a/lib/events.js
+++ b/lib/events.js
@@ -341,7 +341,7 @@ class AdobeIOEvents {
         const applicationId = journal.applicationId || this.defaults.applicationId;
 
         const url =`${IO_API_HOST[this.env]}/events/organizations/${consumerId}/integrations/${applicationId}/registrations`;
-        let response = await fetch(url,{
+        let response = await fetch(url, {
             method: 'POST',
             headers: {
                 'x-api-key': this.auth.clientId,
@@ -357,15 +357,35 @@ class AdobeIOEvents {
         }
         catch (e) {
             if (e.statusCode === 409) {
-                console.error("Journal already exists, returning ID");
+                console.error("Journal already exists, returning existing");
                 const headers = response.headers.raw();
-                if (headers['x-conflicting-id'] === undefined) {
+                const conflictingRegistrationId = headers['x-conflicting-id'][0];
+                if (!headers || !conflictingRegistrationId) {
                     throw e;
                 }
-                response.registration_id = headers['x-conflicting-id'][0];
+                return await getJournal(conflictingRegistrationId);
             }
         }
         return response;
+    }
+
+    /**
+     * Fetches a journal or webhook registration.
+     * @param {String} registrationId the id of the event listener registration to fetch
+     * @returns {Promise}
+     */
+    async getJournal(registrationId, retryOptions=true) {
+        const url =`${IO_API_HOST[this.env]}/events/organizations/${consumerId}/integrations/${applicationId}/registrations/${registrationId}`;
+        let response = await fetch(url,{
+            method: 'GET',
+            headers: {
+                'x-api-key': this.auth.clientId,
+                'x-ims-org-id': this.auth.orgId,
+                'Authorization': `Bearer ${this.auth.accessToken}`,
+            },
+            retryOptions: retryOptions
+        });
+        return handleFetchErrors(response).json();
     }
 
     /**

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -232,6 +232,30 @@ describe('events.js - AdobeIOEvents', function() {
             console.log("        created journal with registration id", response.registration_id);
             journalRegistrationIds.push(response.registration_id);
         });
+
+        it('should return an existing journal on duplicate creation', async () => {
+            const response1 = await ioEvents.createJournal({
+                name: `${getIsoDate(DATE)} - JS test journal - duplicate create`,
+                description: DESCRIPTION,
+                providerId: TEST_PROVIDER_ID,
+                eventTypes: [TEST_EVENT_CODE]
+            });
+            const registrationId1 = response1.registration_id;
+
+            const response2 = await ioEvents.createJournal({
+                name: `${getIsoDate(DATE)} - JS test journal - duplicate create`,
+                description: DESCRIPTION,
+                providerId: TEST_PROVIDER_ID,
+                eventTypes: [TEST_EVENT_CODE]
+            });
+            const registrationId2 = response2.registration_id;
+
+            assert.ok(registrationId1 !== undefined || registrationId1 !== null);
+            assert.ok(registrationId2 !== undefined || registrationId2 !== null);
+            assert.equal(registrationId1, registrationId2);
+            console.log("        fetched existing journal with registration id", registrationId1);
+            journalRegistrationIds.push(registrationId1);
+        });
     });
 
     describe('#sendEvent()', () => {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

This fix handles the 409 Conflict error from IO events when we try to create a journal that has the same name as an existing journal. 
Will fetch the existing journal and return it.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
