### PR TITLE
ASSETS-38305 fix accessing header for registration conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Testing OS CI 2
+Testing OS CI 3
 
 # ⚠️ DISCLAIMER ⚠️
 This is an internal project. It is only meant to be used by [asset-compute-commons](https://github.com/adobe/asset-compute-commons/blob/master/package.json#L12).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Testing OS CI 1
+Testing OS CI 2
 
 # ⚠️ DISCLAIMER ⚠️
 This is an internal project. It is only meant to be used by [asset-compute-commons](https://github.com/adobe/asset-compute-commons/blob/master/package.json#L12).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Testing OS CI 1
+
 # ⚠️ DISCLAIMER ⚠️
 This is an internal project. It is only meant to be used by [asset-compute-commons](https://github.com/adobe/asset-compute-commons/blob/master/package.json#L12).
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -378,7 +378,7 @@ class AdobeIOEvents {
 
         if (response.status === 409) {
             console.error("Journal already exists, returning existing");
-            const conflictingRegistrationId = response.headers['x-conflicting-id'];
+            const conflictingRegistrationId = response.headers.get('x-conflicting-id');
             if (!conflictingRegistrationId) {
                 console.error("Could not find conflicting registration id in response headers");
                 return handleFetchErrors(response);


### PR DESCRIPTION
## Description

For https://jira.corp.adobe.com/browse/ASSETS-38305 
While debugging the 409 conflict issue, noticed that the Header in response object was read incorrectly. 
Its not a Header javascript object, like the code above was assuming it to be, but a Header class.
SLACK Thread: https://cq-dev.slack.com/archives/C6841FMPU/p1714588065493699

```
{
  [Symbol(map)]: [Object: null prototype] {
    server: [ 'openresty' ],
    date: [ 'Thu, 02 May 2024 22:56:58 GMT' ],
    'content-type': [ 'application/json;charset=UTF-8' ],
    'content-length': [ '315' ],
    connection: [ 'close' ],
    'x-request-id': [ 'WN8dcCpL5afjudTSYZ0twjOuIOVD4g2J' ],
    'x-conflicting-id': [ '886068c3-fed5-43a3-867a-d6aaf6979fa5' ],
    'access-control-allow-origin': [ '*' ],
    'access-control-allow-methods': [ 'GET, POST, PUT, DELETE, OPTIONS, PATCH' ],
    'access-control-allow-headers': [
      'X-Requested-With, Origin, Content-Type, Accept, Accept-Language, Authorization, If-Modified-Since, X-Api-Key, X-Ims-Org-Id, x-recaptcha-challenge'
    ],
    'access-control-allow-credentials': [ 'true' ]
  }
```
Fixes # [(issue)](https://jira.corp.adobe.com/browse/ASSETS-38305)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
